### PR TITLE
Adding BoxToVolumesOperator, VolumesToBoxOperator and BoxOperator

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -839,7 +839,7 @@ The `BoxOperator` manages the high-level operations for interacting with Box (do
 - `folder_id`: (required) The ID of the Box folder from which files will be downloaded.
 - `volume_path`: (required) The local path to the volume where files will be downloaded.
 - `file_names`: (optional) A list of specific file names to be downloaded. If not specified, all files in the folder will be downloaded.
-- `file_pattern`: (optional) The pattern to match file names to be downloaded or uploaded.
+- `file_pattern`: (optional) The pattern to match file names starting with or ending with the given file pattern to be downloaded or uploaded.
 - `file_id`: (optional for BoxToVolumesOperator) The ID of a specific file to be downloaded. If specified, only this file will be downloaded. This parameter is not used in VolumesToBoxOperator.
 - `operation`: (required only for BoxOperator) Specifies the operation to be performed: `"download"` or `"upload"`.
 


### PR DESCRIPTION
## Description
The Box Operator provides a comprehensive solution for authenticating with Box and efficiently managing file transfers between Box and Databricks Unity Catalog (UC) volumes. It includes classes for downloading and uploading files, leveraging JWT authentication via BoxAuthenticator.

## Related Issue
Issue created to add Box Operator:
[GitHub Issue #137](https://github.com/Nike-Inc/brickflow/issues/137)

## Motivation and Context
We previously had Box to S3 and S3 to Box operators available in Airflow NGAP. Upon migrating to Databricks, this functionality was missing. We required a solution to download files from Box to Unity Catalog (UC) Volumes and upload files from UC Volumes to Box.


<!--- Why is this change required? What problem does it solve? -->
This operator solves the problem by enabling the download and upload of files between Box and Unity Catalog (UC) Volumes in Databricks.



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
We have thoroughly tested this in a Databricks Notebook using appropriate parameters for various scenarios. 

<!--- Include details of your testing environment, and the tests you ran to -->
All tests are documented in the ⁠ [test_box_operator.py](https://github.com/madhusudan3/brickflow/blob/main/tests/databricks_plugins/test_box_operator.py) ⁠ file, which covers the definitions of all functions used for downloading and uploading files between Box and Unity Catalog (UC) Volumes in Databricks. We achieved approximately 90% code coverage in our ⁠ [test_box_operator.py](https://github.com/madhusudan3/brickflow/blob/main/tests/databricks_plugins/test_box_operator.py) ⁠ ⁠ file. 

<!--- see how your change affects other areas of the code, etc. -->
As this is a new feature, we do not anticipate it affecting other areas of the code.


## Screenshots (if appropriate):
<img width="837" alt="Screenshot 2024-07-22 at 5 18 41 PM" src="https://github.com/user-attachments/assets/fca1aa3f-63b7-46fc-b2a8-3860f38af0ae">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
