### PR TITLE
Adding and testing mkdocs

### DIFF
--- a/docs/faq/faq.md
+++ b/docs/faq/faq.md
@@ -17,6 +17,7 @@ Supported Operators:
 * BashOperator
 * ShortCircuitOperator
 * TaskDependencySensor
+* BoxOperator
 
 To enable the usage of airflow operators, you need to set the `enable_plugins` flag to `True` in the `Project`
 constructor.

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -808,7 +808,7 @@ def tableau_refresh_workbook():
     )
 ```
 
-### Box Operators
+#### Box Operators
 The Box Operator provides a comprehensive solution for authenticating with Box and efficiently managing file transfers 
 between Box and Databricks Unity Catalog (UC) volumes.  It includes classes for downloading and uploading files, 
 leveraging JWT authentication via BoxAuthenticator.
@@ -816,7 +816,7 @@ leveraging JWT authentication via BoxAuthenticator.
 To properly authenticate with Box using JWT within the Databricks or Cerberus environments, 
 ensure that your secrets scope contains the following exact keys:
 
-###### Dbutils or Cerberus
+`Dbutils or Cerberus`
 The secrets scope should contain the following keys for Box authentication:
 
 - `client_id`: `your_client_id` The client ID for the Box application.
@@ -833,7 +833,8 @@ The `VolumesToBoxOperator` uploads files from a Databricks Unity Catalog (UC) vo
 
 The `BoxOperator` manages the high-level operations for interacting with Box (download/upload).
 
-###### BoxToVolumesOperator, VolumesToBoxOperator and BoxOperator Parameters:
+`BoxToVolumesOperator, VolumesToBoxOperator and BoxOperator Parameters:`
+
 - `secret_scope`: (required) The scope within Databricks or Cerberus where the secrets are stored.
 - `cerberus_client_url`: (optional) The URL for the Cerberus client, used to retrieve secrets if not found in the secret_scope.
 - `folder_id`: (required) The ID of the Box folder from which files will be downloaded.
@@ -843,8 +844,6 @@ The `BoxOperator` manages the high-level operations for interacting with Box (do
 - `file_id`: (optional for BoxToVolumesOperator) The ID of a specific file to be downloaded. If specified, only this file will be downloaded. This parameter is not used in VolumesToBoxOperator.
 - `operation`: (required only for BoxOperator) Specifies the operation to be performed: `"download"` or `"upload"`.
 
-
-###### Example Usage
 
 ```python title="box_operators"
 from brickflow.context import ctx


### PR DESCRIPTION
Adding BoxToVolumesOperator, VolumesToBoxOperator and BoxOperator

## Description
The Box Operator provides a comprehensive solution for authenticating with Box and efficiently managing file transfers between Box and Databricks Unity Catalog (UC) volumes. It includes classes for downloading and uploading files, leveraging JWT authentication via BoxAuthenticator.

## Related Issue
Issue created to add Box Operator:
[GitHub Issue #137](https://github.com/Nike-Inc/brickflow/issues/137)

## Motivation and Context
We previously had Box to S3 and S3 to Box operators available in Airflow NGAP. Upon migrating to Databricks, this functionality was missing. We required a solution to download files from Box to Unity Catalog (UC) Volumes and upload files from UC Volumes to Box.


<!--- Why is this change required? What problem does it solve? -->
This operator solves the problem by enabling the download and upload of files between Box and Unity Catalog (UC) Volumes in Databricks.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
We have thoroughly tested this in a Databricks Notebook using appropriate parameters for various scenarios. 


<!--- Include details of your testing environment, and the tests you ran to -->
All tests are documented in the ⁠ [test_box_operator.py](https://github.com/madhusudan3/brickflow/blob/main/tests/databricks_plugins/test_box_operator.py) ⁠ file, which covers the definitions of all functions used for downloading and uploading files between Box and Unity Catalog (UC) Volumes in Databricks. We achieved approximately 90% code coverage in our ⁠ [test_box_operator.py](https://github.com/madhusudan3/brickflow/blob/main/tests/databricks_plugins/test_box_operator.py) ⁠ ⁠ file. 

<!--- see how your change affects other areas of the code, etc. -->
As this is a new feature, we do not anticipate it affecting other areas of the code.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Thanks [Surya Teja Jagatha](https://www.linkedin.com/in/surya-teja-jagatha/) for all the contribution for this Operators.